### PR TITLE
Filtering target platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ dart run build_pipe:publish
 
 Read the topics below to setup and configure your project. The configuration is quite simple, and you just need to do it once.
 
+#### Filtering Target Platforms
 
+By default, `build_pipe` builds all platforms defined in the selected workflow. If you need to build only specific platforms, you can use the `--targets` flag:
+
+```bash
+# Build only Android
+dart run build_pipe:build --targets=android
+
+# Build multiple platforms (comma-separated)
+dart run build_pipe:build --targets=android,ios,web
+```
 
 ## Topics
 

--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -162,10 +162,15 @@ class BPConfig {
     }
 
     String workflowName = "default";
+    List<String> targetFilter = [];
     List<String> downstreamargs = [];
     for (var arg in args) {
       if (arg.startsWith("--workflow=")) {
         workflowName = arg.split("=")[1];
+        continue;
+      }
+      if (arg.startsWith("--targets=")) {
+        targetFilter = arg.split("=")[1].split(",");
         continue;
       }
       downstreamargs.add(arg);
@@ -183,11 +188,25 @@ class BPConfig {
       // just in case the + doesnt exist
       pubspec["version"].split("+").length > 1 ? pubspec["version"].split("+")[1] : "0",
     );
+    
+    if (config.$1 != null && targetFilter.isNotEmpty) {
+      config.$1?.applyTargetFilter(targetFilter);      
+    }
 
     if (config.$1 != null && config.$1!.publishPlatforms.isEmpty && config.$1!.buildPlatforms.isEmpty) {
       return (null, [(Console.logError, "No target platforms were detected. Please add your target platforms to pubspec")]);
     }
 
     return config;
+  }
+
+  void applyTargetFilter(List<String> allowedTargets) {
+    final targets = allowedTargets.map((e) => e.toLowerCase().trim()).toList();
+    if (!targets.contains("android")) android = null;
+    if (!targets.contains("ios")) ios = null;
+    if (!targets.contains("macos")) macos = null;
+    if (!targets.contains("linux")) linux = null;
+    if (!targets.contains("windows")) windows = null;
+    if (!targets.contains("web")) web = null;
   }
 }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -38,4 +38,40 @@ void main() {
       expect(configAndErrors.$2, hasLength(1));
     });
   });
+
+  test('Should filter platforms using --targets', () async {      
+      var singleTarget = await BPConfig.readPubspec(
+        ["--targets=android"], 
+        "test/sample/valid_all_options.yaml"
+      );
+      expect(singleTarget.$1, isNotNull);
+      expect(singleTarget.$1!.buildPlatforms, hasLength(1));
+      expect(singleTarget.$1!.buildPlatforms.first.name, "android");      
+      expect(singleTarget.$1!.cmdArgs, isNot(contains("--targets=android")));
+      
+      var multiTarget = await BPConfig.readPubspec(
+        ["--targets=android,web,macos"], 
+        "test/sample/valid_all_options.yaml"
+      );
+      expect(multiTarget.$1, isNotNull);
+      expect(multiTarget.$1!.buildPlatforms, hasLength(3));
+      final names = multiTarget.$1!.buildPlatforms.map((p) => p.name).toList();
+      expect(names, containsAll(["android", "web", "macos"]));
+
+      var capsTarget = await BPConfig.readPubspec(
+        ["--targets=ANDROID"], 
+        "test/sample/valid_all_options.yaml"
+      );
+      expect(capsTarget.$1!.buildPlatforms, hasLength(1));
+    });
+
+    test('Should return error if filtered targets result in empty list', () async {      
+      var errorTarget = await BPConfig.readPubspec(
+        ["--targets=nokia_3310"], 
+        "test/sample/valid_all_options.yaml"
+      );
+            
+      expect(errorTarget.$1, isNull);
+      expect(errorTarget.$2.last.$2, contains("No target platforms were detected"));
+    });
 }


### PR DESCRIPTION
To improve integrations with CI/CI when only custom target is required for a single atomic job